### PR TITLE
Added note about params coerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ memoized("12", true); // Cache hit
 memoized({ toString: function () { return "12"; } }, {}); // Cache hit
 ```
 
+__Note. You MUST coerce arrays / objects / functions, if used as parameters__. The most simple
+(but not safe) way, is casting parameters to strings - just use _primitive_ mode. If `String(your_param)`
+is not unique - provide resolvers directly, as custom function.
+
+
 ### Memoizing asynchronous functions
 
 With _async_ option we indicate that we memoize asynchronous function.  


### PR DESCRIPTION
User can miss, that arrays / objects / functions must be coerced, when used as params. Then memoise will not work as expected and can cause memory leak.

Added note to readme.
