### PR TITLE
fixed typo in readme in section: memoizing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ var memoizeMethods = require('memoizee/methods');
 var Foo = function () {
   // ... constructor logic
 };
-Object.definePropeties(Foo.prototype, memoizeMethods({
+Object.defineProperties(Foo.prototype, memoizeMethods({
   bar: d(function () {
     // ... method logic
   }, { someOption: true })


### PR DESCRIPTION
There was a typo with the readme.
