### PR TITLE
Preserve rejection state when using a .then reject handler

### DIFF
--- a/ext/promise.js
+++ b/ext/promise.js
@@ -63,8 +63,9 @@ require('../lib/registered-extensions').promise = function (mode, conf) {
 			} else {
 				promise.then(function (result) {
 					nextTick(onSuccess.bind(this, result));
-				}, function () {
+				}, function (error) {
 					nextTick(onFailure);
+					throw error
 				});
 			}
 		}

--- a/ext/promise.js
+++ b/ext/promise.js
@@ -65,7 +65,7 @@ require('../lib/registered-extensions').promise = function (mode, conf) {
 					nextTick(onSuccess.bind(this, result));
 				}, function (error) {
 					nextTick(onFailure);
-					throw error
+					throw error;
 				});
 			}
 		}


### PR DESCRIPTION
On any Promises/A+ implementation, throwing in the reject handler will propagate the rejection.