### PR TITLE
Use directly binaries on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "xlint-jslint-medikoo": "^0.1.4"
   },
   "scripts": {
-    "lint": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --no-cache --no-stream",
-    "lint-console": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
-    "test": "node node_modules/tad/bin/tad"
+    "lint": "npm run lint-medikoo -- --no-cache --no-stream",
+    "lint-console": "npm run lint-medikoo -- --watch",
+    "lint-medikoo": "xlint --linter=node_modules/xlint-jslint-medikoo/index.js",
+    "test": "tad"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I find it clearer to use directly the binaries in the package.json scripts.
You can do this according to: https://docs.npmjs.com/cli/run-script#description

Instead of doing this: `node node_modules/tad/bin/tad` we can do this: `tad`.
Thanks to the `node_modules/.bin` folder. 
We can also reuse internal commands such as `lint-medikoo`