### PR TITLE
Cannot use 'normalizer' with WeakMap mode

### DIFF
--- a/lib/resolve-normalize.js
+++ b/lib/resolve-normalize.js
@@ -8,8 +8,8 @@ module.exports = function (userNormalizer) {
 	normalizer = { get: callable(userNormalizer.get) };
 	if (userNormalizer.set !== undefined) {
 		normalizer.set = callable(userNormalizer.set);
-		normalizer.delete = callable(userNormalizer.delete);
-		normalizer.clear = callable(userNormalizer.clear);
+		if (userNormalizer.delete) normalizer.delete = callable(userNormalizer.delete);
+		if (userNormalizer.clear) normalizer.clear = callable(userNormalizer.clear);
 		return normalizer;
 	}
 	normalizer.set = normalizer.get;

--- a/test/lib/resolve-normalize.js
+++ b/test/lib/resolve-normalize.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function (t, a) {
-	var fn = function () {};
-	a.deep(t(fn), { get: fn, set: fn });
+	var fn = function () {}, resolved = t(fn);
+	a.deep(resolved, { get: fn, set: fn });
+	a.deep(t(resolved), { get: fn, set: fn });
 };


### PR DESCRIPTION
We cannot use `normalizer` option with weakmap mode.
When combined with normalizer, it throws a TypeError: undefined is not a function.

Example usage: 
```typescript
const weakMemoize = require('memoize/weak');

function findById(id): Model { ... }

function findMetaById(id): ModelMeta { ... }

// throws error
weakMemoize(findMetaById, { normalizer: (args) => findById(args[0]) });
```