### PR TITLE
Expose `get` and `has` methods

### DIFF
--- a/lib/configure-map.js
+++ b/lib/configure-map.js
@@ -13,8 +13,8 @@ var customError      = require('es5-ext/error/custom')
   , on = ee.on, emit = ee.emit;
 
 module.exports = function (original, length, options) {
-	var cache = create(null), conf, memLength, get, set, del, clear, extDel, extGet, extHas, normalizer
-	  , getListeners, setListeners, deleteListeners, memoized, resolve;
+	var cache = create(null), conf, memLength, get, set, del, clear, extDel,
+		extGet, extHas, normalizer, getListeners, setListeners, deleteListeners, memoized, resolve;
 	if (length !== false) memLength = length;
 	else if (isNaN(original.length)) memLength = 1;
 	else memLength = original.length;
@@ -135,24 +135,24 @@ module.exports = function (original, length, options) {
 			return conf.delete(arg);
 		};
 	}
-	extGet = function () {
+	extGet = defineLength(function () {
 		var id, args = arguments;
 		if (resolve) args = resolve(args);
 		id = get(args);
 		return cache[id];
-	};
-	extHas = function () {
+	});
+	extHas = defineLength(function () {
 		var id, args = arguments;
 		if (resolve) args = resolve(args);
 		id = get(args);
 		return conf.has(id);
-	};
+	});
 	defineProperties(memoized, {
 		__memoized__: d(true),
 		delete: d(extDel),
 		clear: d(conf.clear),
-		get: d(extGet),
-		has: d(extHas)
+		_get: d(extGet),
+		_has: d(extHas)
 	});
 	return conf;
 };

--- a/lib/configure-map.js
+++ b/lib/configure-map.js
@@ -145,6 +145,7 @@ module.exports = function (original, length, options) {
 		var id, args = arguments;
 		if (resolve) args = resolve(args);
 		id = get(args);
+		if (id === null) return false;
 		return conf.has(id);
 	});
 	defineProperties(memoized, {

--- a/lib/configure-map.js
+++ b/lib/configure-map.js
@@ -13,7 +13,7 @@ var customError      = require('es5-ext/error/custom')
   , on = ee.on, emit = ee.emit;
 
 module.exports = function (original, length, options) {
-	var cache = create(null), conf, memLength, get, set, del, clear, extDel, normalizer
+	var cache = create(null), conf, memLength, get, set, del, clear, extDel, extGet, extHas, normalizer
 	  , getListeners, setListeners, deleteListeners, memoized, resolve;
 	if (length !== false) memLength = length;
 	else if (isNaN(original.length)) memLength = 1;
@@ -135,10 +135,24 @@ module.exports = function (original, length, options) {
 			return conf.delete(arg);
 		};
 	}
+	extGet = function () {
+		var id, args = arguments;
+		if (resolve) args = resolve(args);
+		id = get(args);
+		return cache[id];
+	};
+	extHas = function () {
+		var id, args = arguments;
+		if (resolve) args = resolve(args);
+		id = get(args);
+		return conf.has(id);
+	};
 	defineProperties(memoized, {
 		__memoized__: d(true),
 		delete: d(extDel),
-		clear: d(conf.clear)
+		clear: d(conf.clear),
+		get: d(extGet),
+		has: d(extHas)
 	});
 	return conf;
 };

--- a/test/lib/configure-map.js
+++ b/test/lib/configure-map.js
@@ -25,6 +25,20 @@ module.exports = function () {
 			a(mfn(y, 'bar', 'zeta'), 'foobarzeta', "#3");
 			a(i, 2, "Called twice");
 		},
+		get: function (a) {
+			var fn = function (x) { return x; }, mfn;
+			mfn = memoize(fn);
+			a(mfn.get('foo'), undefined);
+			mfn('foo');
+			a(mfn.get('foo'), 'foo');
+		},
+		has: function (a){
+			var fn = function (x) { return x; }, mfn;
+			mfn = memoize(fn);
+			a(mfn.has('foo'), false);
+			mfn('foo');
+			a(mfn.has('foo'), true);
+		},
 		Circular: function (a) {
 			var i = 0, fn;
 			fn = memoize(function (x) {

--- a/test/lib/configure-map.js
+++ b/test/lib/configure-map.js
@@ -25,19 +25,19 @@ module.exports = function () {
 			a(mfn(y, 'bar', 'zeta'), 'foobarzeta', "#3");
 			a(i, 2, "Called twice");
 		},
-		get: function (a) {
+		_get: function (a) {
 			var fn = function (x) { return x; }, mfn;
 			mfn = memoize(fn);
-			a(mfn.get('foo'), undefined);
+			a(mfn._get('foo'), undefined);
 			mfn('foo');
-			a(mfn.get('foo'), 'foo');
+			a(mfn._get('foo'), 'foo');
 		},
-		has: function (a){
+		_has: function (a) {
 			var fn = function (x) { return x; }, mfn;
 			mfn = memoize(fn);
-			a(mfn.has('foo'), false);
+			a(mfn._has('foo'), false);
 			mfn('foo');
-			a(mfn.has('foo'), true);
+			a(mfn._has('foo'), true);
 		},
 		Circular: function (a) {
 			var i = 0, fn;


### PR DESCRIPTION
This has been mentioned in a few issues (https://github.com/medikoo/memoizee/issues/45, https://github.com/medikoo/memoizee/issues/33, https://github.com/medikoo/memoizee/issues/51).

The goal is to expose `get` and `has` methods so that we easily have read access to the cache, depending on the arguments.
Hopefully, the tests will demonstrate really well how this works. 

I tried to match your coding style, I am happy to take any feedback.
This would be really useful for my use case described here: https://github.com/medikoo/memoizee/issues/33#issuecomment-278046852

I know you're planning to do a major refactor soon, but in the meantime, I think that exposing those 2 new methods are costless and will be really useful to some people, me included :)

Many thanks.