### PR TITLE
Add support for removing cancelled bluebird3 promises from the cache.

### DIFF
--- a/ext/promise.js
+++ b/ext/promise.js
@@ -65,10 +65,17 @@ require("../lib/registered-extensions").promise = function (mode, conf) {
 		if (!resolvedMode) resolvedMode = "then";
 
 		if (resolvedMode === "then") {
+			var nextTickFailure = function () {
+				nextTick(onFailure);
+			};
 			promise.then(
 				function (result) { nextTick(onSuccess.bind(this, result)); },
-				function () { nextTick(onFailure); }
+				nextTickFailure
 			);
+			// If `finally` is a function we attach to it to remove cancelled promises.
+			if (typeof promise.finally === "function") {
+				promise.finally(nextTickFailure);
+			}
 		} else if (resolvedMode === "done") {
 			// Not recommended, as it may mute any eventual "Unhandled error" events
 			if (typeof promise.done !== "function") {
@@ -95,12 +102,6 @@ require("../lib/registered-extensions").promise = function (mode, conf) {
 			}
 			promise.done(onSuccess);
 			promise.finally(onFailure);
-		}
-
-		// If `_attachCancellationCallback` is a function we attach to it to remove cancelled
-		// promises from the cache.
-		if (typeof promise._attachCancellationCallback === "function") {
-			promise._attachCancellationCallback(onFailure);
 		}
 	});
 

--- a/ext/promise.js
+++ b/ext/promise.js
@@ -96,6 +96,12 @@ require("../lib/registered-extensions").promise = function (mode, conf) {
 			promise.done(onSuccess);
 			promise.finally(onFailure);
 		}
+
+		// If `_attachCancellationCallback` is a function we attach to it to remove cancelled
+		// promises from the cache.
+		if (typeof promise._attachCancellationCallback === "function") {
+			promise._attachCancellationCallback(onFailure);
+		}
 	});
 
 	// From cache (sync)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "timers-ext": "^0.1.5"
   },
   "devDependencies": {
+    "bluebird": "^3.5.1",
     "eslint": "^5.3",
     "eslint-config-medikoo-es5": "^1.6",
     "plain-promise": "^0.1.1",

--- a/test/ext/promise.js
+++ b/test/ext/promise.js
@@ -174,7 +174,7 @@ module.exports = function () {
 							res(x + y);
 						}, 100);
 					});
-					setTimeout(function () {
+					nextTick(function () {
 						p.cancel();
 					}, 1);
 					return p;
@@ -196,8 +196,8 @@ module.exports = function () {
 					setTimeout(function (err) {
 						a(i, 4, "Again Called #2");
 						d();
-					}, 10);
-				}, 10);
+					}, 500);
+				}, 500);
 			}
 		},
 		"Primitive": {

--- a/test/ext/promise.js
+++ b/test/ext/promise.js
@@ -1,10 +1,16 @@
-/* eslint id-length: 0, handle-callback-err: 0, no-undef: 0, no-unused-vars: 0, func-names: 0 */
+/* eslint id-length: 0, handle-callback-err: 0, no-undef: 0, no-unused-vars: 0, func-names: 0,
+max-lines: 0 */
 
 "use strict";
 
 var memoize  = require("../..")
   , nextTick = require("next-tick")
-  , Promise  = require("plain-promise");
+  , Promise  = require("plain-promise")
+  , Bluebird = require("bluebird");
+
+Bluebird.config({
+	cancellation: true
+});
 
 module.exports = function () {
 	return {
@@ -102,6 +108,90 @@ module.exports = function () {
 					mfn(3, 7).done(a.never, function (err) { a(err, e, "Again: Result"); });
 
 					mfn(5, 8).done(a.never, function (err) { a(err, e, "Again B: Result"); });
+
+					setTimeout(function (err) {
+						a(i, 4, "Again Called #2");
+						d();
+					}, 10);
+				}, 10);
+			}
+		},
+		"Cancellation": {
+			Immediate: function (a, d) {
+				var mfn, fn, i = 0;
+				fn = function (x, y) {
+					++i;
+					var p = new Bluebird(function (res) {
+						setTimeout(function () {
+							res(x + y);
+						}, 100);
+					});
+					p.cancel();
+					return p;
+				};
+
+				mfn = memoize(fn, { promise: true });
+
+				mfn(3, 7).done(a.never, function (err) {
+					a.throws(function () {
+						throw err;
+					}, Bluebird.CancellationError, "Result #1");
+				});
+
+				mfn(5, 8).done(a.never, function (err) {
+					a.throws(function () {
+						throw err;
+					}, Bluebird.CancellationError, "Result B #2");
+				});
+
+				setTimeout(function () {
+					a(i, 2, "Called #2");
+
+					mfn(3, 7).done(a.never, function (err) {
+						a.throws(function () {
+							throw err;
+						}, Bluebird.CancellationError, "Again: Result");
+					});
+
+					mfn(5, 8).done(a.never, function (err) {
+						a.throws(function () {
+							throw err;
+						}, Bluebird.CancellationError, "Again B: Result");
+					});
+
+					setTimeout(function (err) {
+						a(i, 4, "Again Called #2");
+						d();
+					}, 10);
+				}, 10);
+			},
+			Delayed: function (a, d) {
+				var mfn, fn, i = 0;
+				fn = function (x, y) {
+					++i;
+					var p = new Bluebird(function (res) {
+						setTimeout(function () {
+							res(x + y);
+						}, 100);
+					});
+					setTimeout(function () {
+						p.cancel();
+					}, 1);
+					return p;
+				};
+
+				mfn = memoize(fn, { promise: true });
+
+				mfn(3, 7).done(a.never, a.never);
+
+				mfn(5, 8).done(a.never, a.never);
+
+				setTimeout(function () {
+					a(i, 2, "Called #2");
+
+					mfn(3, 7).done(a.never, a.never);
+
+					mfn(5, 8).done(a.never, a.never);
 
 					setTimeout(function (err) {
 						a(i, 4, "Again Called #2");


### PR DESCRIPTION
When a bluebird3 promise is cancelled it doesn't call any success/failure handles which means that it appears to be permanently waiting in terms of the cache and will be given out to every subsequent call.
This is a problem as when you try to subscribe to the returned, cancelled, promise it rejects with a CancellationError so we end up with a poisoned cache.  This PR checks if the promise can attach cancellation handlers and if so we attach the `onFailure` handler to clean up in case of cancellation