### PR TITLE
chore: Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
-test/
-benchmark/
-.editorconfig
-.testignore
-.github/FUNDING.yml
+/.editorconfig
+/.github
+/.testignore
+/test
+/benchmark
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+test/
+benchmark/
+.editorconfig
+.testignore
+.github/FUNDING.yml
+


### PR DESCRIPTION
Reduced package size by removing tests, benchmark and other non-relevant files from published package. Unpacked size went from 266.5 kB to 62.8 kB.

<details>
<summary>Before</summary>

```
➜  memoizee git:(a3bb4be) npm publish --dry-run
npm notice 
npm notice 📦  memoizee@0.4.14
npm notice === Tarball Contents === 
...          
npm notice === Tarball Details === 
npm notice name:          memoizee                                
npm notice version:       0.4.14                                  
npm notice package size:  37.2 kB                                 
npm notice unpacked size: 266.5 kB                                
npm notice shasum:        c5cfd766e8008c51886784b917c8c60f189d615c
npm notice integrity:     sha512-ucJijywclHuHa[...]2OsFUVwkahrog==
npm notice total files:   59                                      
npm notice 
+ memoizee@0.4.14
```

</details>

<details>
<summary>After</summary>

```
➜  memoizee git:(master) ✗ npm publish --dry-run
npm notice 
npm notice 📦  memoizee@0.4.14
npm notice === Tarball Contents === 
...            
npm notice === Tarball Details === 
npm notice name:          memoizee                                
npm notice version:       0.4.14                                  
npm notice package size:  19.1 kB                                 
npm notice unpacked size: 62.8 kB                                 
npm notice shasum:        1ae7608171055e241cada82acf6b79fbc168280a
npm notice integrity:     sha512-FNZP6oHLrehey[...]6k80NoLHyt67g==
npm notice total files:   30                                      
npm notice 
+ memoizee@0.4.14
```

</details>