### PR TITLE
chore: update package.json to do not reference vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "d": "^1.0.1",
-    "es5-ext": "^0.10.53",
+    "es5-ext": "^0.10.63",
     "es6-weak-map": "^2.0.3",
     "event-emitter": "^0.3.5",
     "is-promise": "^2.2.2",


### PR DESCRIPTION
fix: #133

note, no changes to `package-lock.json` since correct version already referenced there (which still didn't stop security scanners from blaming this repo/package)