### PR TITLE
fix node version package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"test": "tad"
 	},
 	"engines": {
-		"node": ">=0.12"
+		"node": ">=18.0.0"
 	},
 	"license": "ISC"
 }


### PR DESCRIPTION
Here bro. Or remove the engine part completely, if you dont need it. But 18 is still in maintenance https://nodejs.org/en/about/previous-releases